### PR TITLE
Fix GTP latency test

### DIFF
--- a/pktgen/app/pktgen.c
+++ b/pktgen/app/pktgen.c
@@ -206,7 +206,7 @@ pktgen_find_matching_ipdst(port_info_t *info, uint32_t addr)
 }
 
 static __inline__ latency_t *
-pktgen_latency_pointer(port_info_t *info, struct rte_mbuf *m)
+pktgen_latency_pointer(port_info_t *info, struct rte_mbuf *m, bool skip_gtp)
 {
 	latency_t *latency;
 	char *p;
@@ -221,8 +221,15 @@ pktgen_latency_pointer(port_info_t *info, struct rte_mbuf *m)
 	p += (info->seq_pkt[SINGLE_PKT].ipProto == IPPROTO_UDP) ?
 		sizeof(struct udp_hdr) : sizeof(struct tcp_hdr);
 
-	/* Force pointer to be aligned correctly */
-	p = RTE_PTR_ALIGN_CEIL(p, sizeof(uint64_t));
+    if (skip_gtp) {
+        p += sizeof(gtpuHdr_t);
+
+        p += (info->seq_pkt[SINGLE_PKT].ethType == ETHER_TYPE_IPv4) ?
+            sizeof(struct ipv4_hdr) : sizeof(struct ipv6_hdr);
+
+        p += (info->seq_pkt[SINGLE_PKT].ipProto == IPPROTO_UDP) ?
+		    sizeof(struct udp_hdr) : sizeof(struct tcp_hdr);
+    }
 
 	latency = (latency_t *)p;
 
@@ -237,7 +244,7 @@ pktgen_latency_apply(port_info_t *info __rte_unused,
 	int i;
 
 	for (i = 0; i < cnt; i++) {
-		latency = pktgen_latency_pointer(info, mbufs[i]);
+		latency = pktgen_latency_pointer(info, mbufs[i], traffic_gen_as == IL_TRAFFIC_GEN);
 
 		latency->timestamp  = rte_rdtsc_precise();
 		latency->magic      = LATENCY_MAGIC;
@@ -417,7 +424,7 @@ pktgen_recv_latency(port_info_t *info, struct rte_mbuf **pkts, uint16_t nb_pkts)
 		latency_t *latency;
 
 		for (i = 0; i < nb_pkts; i++) {
-			latency = pktgen_latency_pointer(info, pkts[i]);
+			latency = pktgen_latency_pointer(info, pkts[i], traffic_gen_as == IL_TRAFFIC_GEN);
 
 			if (latency->magic == LATENCY_MAGIC) {
 				lat = (rte_rdtsc_precise() - latency->timestamp);

--- a/pktgen/app/pktgen.c
+++ b/pktgen/app/pktgen.c
@@ -248,6 +248,21 @@ pktgen_latency_apply(port_info_t *info __rte_unused,
 
 		latency->timestamp  = rte_rdtsc_precise();
 		latency->magic      = LATENCY_MAGIC;
+
+        // Ignore L4 checksum
+        char *l4_hdr, *p = rte_pktmbuf_mtod(mbufs[i], char *);
+        p += sizeof(struct ether_hdr);
+        p += (info->seq_pkt[SINGLE_PKT].ethType == ETHER_TYPE_IPv4) ?
+            sizeof(struct ipv4_hdr) : sizeof(struct ipv6_hdr);
+        l4_hdr = p;
+
+        if (info->seq_pkt[SINGLE_PKT].ipProto == IPPROTO_UDP) {
+            struct udp_hdr *udp_hdr = (struct udp_hdr*)l4_hdr;
+            udp_hdr->dgram_cksum = 0;
+        } else {
+            struct tcp_hdr *tcp_hdr = (struct tcp_hdr*)l4_hdr;
+            tcp_hdr->cksum = 0;
+        }
 	}
 }
 


### PR DESCRIPTION
Hi,
I made this patch because I found that the latency testing is not skipping the GTP header to inject timestamp in the payload when generating S1-U packets.
Please point out if I am not understanding correctly, thank you.
